### PR TITLE
refactored transactions

### DIFF
--- a/src/main/java/com/github/tripflow/core/port/db/DbPersistenceOperationsOutputPort.java
+++ b/src/main/java/com/github/tripflow/core/port/db/DbPersistenceOperationsOutputPort.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public interface DbPersistenceOperationsOutputPort {
 
-    void rollback();
+    void doInTransaction(Runnable runnable);
 
     void saveNewTrip(Trip trip);
 

--- a/src/main/java/com/github/tripflow/core/usecase/browse/BrowseActiveTripsUseCase.java
+++ b/src/main/java/com/github/tripflow/core/usecase/browse/BrowseActiveTripsUseCase.java
@@ -19,8 +19,8 @@ public class BrowseActiveTripsUseCase implements BrowseActiveTripsInputPort {
     @Override
     public void listEntriesForActiveTripsStartedByUser() {
 
-        List<TripEntry> tripEntries;
         try {
+            List<TripEntry> tripEntries;
             // get all active tasks for trips started by the user
             String loggedInUserName = securityOps.loggedInUserName();
             securityOps.assertCustomerPermission(loggedInUserName);
@@ -29,11 +29,10 @@ public class BrowseActiveTripsUseCase implements BrowseActiveTripsInputPort {
 
             tripEntries = dbOps.findAllOpenTripsForUser(candidateGroups, loggedInUserName);
 
+            presenter.presentActiveTasksForTripsStartedByUser(tripEntries);
         } catch (Exception e) {
             presenter.presentError(e);
-            return;
         }
 
-        presenter.presentActiveTasksForTripsStartedByUser(tripEntries);
     }
 }


### PR DESCRIPTION
Remove `@Transactional` on the use cases, handle transactions on the individual methods of the gateway. Provide for a possibility to manually run a block of code in a use case as transactional, if needed (using `org.springframework.transaction.support.TransactionTemplate` in the persistence gateway).